### PR TITLE
added Auto-Complete for ticket assignee

### DIFF
--- a/src/pages/TicketPage.tsx
+++ b/src/pages/TicketPage.tsx
@@ -13,7 +13,7 @@ import { Button, Grid, Stack, Typography } from '@mui/material';
 import { DASSnackbar } from '../components/DASSnackbar';
 import { UserContext } from '../components/contexts/UserContext';
 import { TicketHistoryCard, TicketLongForm } from '../sections/tickets/TicketComponents';
-import { Ticket, ticketService } from '../sections/tickets/ticketService';
+import { Ticket, Staff, ticketService} from '../sections/tickets/ticketService';
 
 const Labels = {
   updateMessage: 'Ticket updated.',
@@ -26,6 +26,7 @@ const TicketPage = () => {
   const [ticket, setTicket] = useState<Ticket>();
   const [changes, setChanges] = useState<Record<string, unknown>>({});
   const [openSnack, setOpenSnack] = useState<boolean>(false);
+  const [staff, setStaff] = useState<Staff[]>();
 
   useEffect(() => {
     ticketService.getTicket(Number(id))
@@ -34,6 +35,13 @@ const TicketPage = () => {
         setChanges({});
       })
   }, [id]);
+
+  useEffect(() => {
+    ticketService.getStaff()
+      .then((resp: Staff[]) => {
+        setStaff(resp);
+      })
+  }, []);
 
   const handleChange = (field: string, value: unknown) => {
     changes[field] = value;
@@ -87,7 +95,7 @@ const TicketPage = () => {
 
         {/* row 2 */}
         <Grid item xs={12} md={7} lg={8}>
-          <TicketLongForm ticket={ticket} onChanged={handleChange} />
+          <TicketLongForm ticket={ticket} onChanged={handleChange} staff={staff} />
         </Grid>
         <Grid item xs={12} md={5} lg={4}>
           <TicketHistoryCard ticket={ticket} />

--- a/src/sections/tickets/TicketComponents.tsx
+++ b/src/sections/tickets/TicketComponents.tsx
@@ -1,9 +1,9 @@
-import { Link, MenuItem, Select, Stack, TextField, Typography } from "@mui/material";
+import { Link, MenuItem, Select, Stack, TextField, Typography, Autocomplete } from "@mui/material";
 import moment from "moment";
 import { Link as RouterLink } from 'react-router-dom';
 import Dot from "../../components/@extended/Dot";
 import MainCard from "../../components/MainCard";
-import { Ticket, TicketHistory } from "./ticketService";
+import { Ticket, TicketHistory, Staff } from "./ticketService";
 import useAppConstants from "../../services/useAppConstants";
 
 
@@ -60,9 +60,10 @@ const TicketLink: React.FC<TicketProps> = ({ ticket }) => {
 // project import
 interface TicketFormProps extends TicketProps {
     onChanged: (field: string, value: unknown) => void;
+    staff: Staff[];
 }
 
-const TicketLongForm: React.FC<TicketFormProps> = ({ ticket, onChanged }) => {
+const TicketLongForm: React.FC<TicketFormProps> = ({ ticket, staff, onChanged }) => {
     const { data: sources } = useAppConstants('SOURCE');
 
     return (
@@ -129,6 +130,16 @@ const TicketLongForm: React.FC<TicketFormProps> = ({ ticket, onChanged }) => {
                     onChange={(event) => onChanged('inputSource', event.target.value)}                    >
                     {sources.map((s, idx: number) => <MenuItem key={idx} value={s.value}>{s.label}</MenuItem>)}
                 </Select>
+                <Autocomplete
+                    id="assignee"
+                    value={ticket.assignee}
+                    onChange={(_event: any, newValue: string | null) => {
+                        onChanged('assignee', newValue);
+                    }}
+                    sx={{width:"100%"}}
+                    options={staff ? staff.map(e=> e.name) : []}
+                    renderInput={(params) => <TextField {...params} label="Assigned to" />}
+                />
             </Stack>
         </MainCard>
     )

--- a/src/sections/tickets/ticketService.test.ts
+++ b/src/sections/tickets/ticketService.test.ts
@@ -140,4 +140,18 @@ describe('ticketService tests', () => {
         expect(actual).toEqual(expected);
     });
 
+    it('getStaff', async () => {
+        const response = { data: [{}], error: null }
+        const fromSpy = vi.spyOn(supabaseClient, "from")
+            .mockReturnValue(mockQueryBuilder as any)
+        const selectSpy = vi.spyOn(mockQueryBuilder, "select")
+            .mockReturnValue(mockFilterBuilder as any)
+            .mockReturnValue(Promise.resolve(response))
+
+        const tixs = await ticketService.getStaff()
+        expect(fromSpy).toHaveBeenCalledWith('staff')
+        expect(selectSpy).toHaveBeenCalled()
+        expect(tixs.length).toEqual(1);
+    });
+
 })

--- a/src/sections/tickets/ticketService.ts
+++ b/src/sections/tickets/ticketService.ts
@@ -33,6 +33,14 @@ type TicketHistory = {
     change_by: string
 };
 
+type Staff = {
+    id: number,
+    created_at: Date,
+    name: string,
+    email: string,
+    roles: string,
+};
+
 class TicketService {
     async query(query: QueryModel): Promise<PageInfo<Ticket>> {
         const _offset = query.page ? query.page * query.pageSize : 0;
@@ -106,9 +114,16 @@ class TicketService {
             .select()
             .then(histResp => histResp.data![0] as TicketHistory);
     }
+
+    async getStaff(): Promise<Staff[]> {
+        return supabaseClient.from('staff')
+            .select()
+            .then(tixResp => tixResp.data as Staff[])
+    }
+
 }
 
 const ticketService = new TicketService()
 export { ticketService };
-export type { PageInfo, Ticket, TicketHistory };
+export type { PageInfo, Ticket, Staff, TicketHistory };
 


### PR DESCRIPTION
- I noticed you have done ticket update for other fields, so for consistency I also used the same for updating assignee of the ticket. 

- database changes: staff table name field changed to be unique and is referenced for ticket_service (assignee field foreign-key).

- getStaff() added to ticket service to retreive data from staff table for assignee Autocomplete options. 