### PR TITLE
bread crumbs bug fixed

### DIFF
--- a/src/components/@extended/Breadcrumbs.tsx
+++ b/src/components/@extended/Breadcrumbs.tsx
@@ -81,7 +81,7 @@ const Breadcrumbs: React.FC<PROPS> = ({ navigation, title, others }) => {
           <Grid container direction="column" justifyContent="flex-start" alignItems="flex-start" spacing={1}>
             <Grid item>
               <MuiBreadcrumbs aria-label="breadcrumb">
-                <Typography component={Link} to="/" color="textSecondary" variant="h6" sx={{ textDecoration: 'none' }}>
+                <Typography component={Link} to="/dashboard" color="textSecondary" variant="h6" sx={{ textDecoration: 'none' }}>
                   Home
                 </Typography>
                 {mainContent}

--- a/src/components/@extended/Breadcrumbs.tsx
+++ b/src/components/@extended/Breadcrumbs.tsx
@@ -81,7 +81,7 @@ const Breadcrumbs: React.FC<PROPS> = ({ navigation, title, others }) => {
           <Grid container direction="column" justifyContent="flex-start" alignItems="flex-start" spacing={1}>
             <Grid item>
               <MuiBreadcrumbs aria-label="breadcrumb">
-                <Typography component={Link} to="/dashboard" color="textSecondary" variant="h6" sx={{ textDecoration: 'none' }}>
+                <Typography component={Link} to="/" color="textSecondary" variant="h6" sx={{ textDecoration: 'none' }}>
                   Home
                 </Typography>
                 {mainContent}

--- a/src/menu-items/index.tsx
+++ b/src/menu-items/index.tsx
@@ -39,7 +39,7 @@ const dashboard = {
       id: 'dashboard',
       title: 'Dashboard',
       type: 'item',
-      url: '/dashboard',
+      url: '/',
       icon: icons.DashboardOutlined,
       breadcrumbs: false
     },

--- a/src/pages/routes.tsx
+++ b/src/pages/routes.tsx
@@ -23,10 +23,6 @@ const routes = [
         element: <DashboardDefault />,
       },
       {
-        path: "dashboard",
-        element: <DashboardDefault />,
-      },
-      {
         path: "sample-page",
         element: <SamplePage />,
       },


### PR DESCRIPTION
## Description

_ Since there is no item defined for root path / in src/menu-items/index 
with breadcrumbs:false not showing bread crumbs works for / path 
but if we change it to /dashboard and there is a item there with breadcrumbs: false 
when redirecting to /dashboard it does not show the breadcrumbs.



## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [* ] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Ticket 9578 fix bread crumbs

_Link user story from projects.digitalaidseattle.org_

- Closes # 9578
